### PR TITLE
Fixed ctop for mutually exclusive arguments

### DIFF
--- a/ctop/_ctop
+++ b/ctop/_ctop
@@ -1,14 +1,17 @@
 #compdef _ctop ctop
 
 _ctop() {
+    local I
+    I='-h -v'
+
     _arguments \
-        '-a[show active containers only]' \
-        '-connector[container connector to use (default "docker")]:connector:()' \
-        '-f[filter containers]:filter:()' \
-        '-h[display help dialog]' \
-        '-i[invert default colors]' \
-        '-r[reverse container sort order]' \
-        '-s[select container sort field]:sort by:(id name cpu mem "mem %" net pids io state)' \
-        '-scale-cpu[show cpu as % of system total]' \
-        '-v[output version information and exit]'
+        "($I)-a[show active containers only]" \
+        "($I)-connector[container connector to use (default \"docker\")]:connector:()" \
+        "($I)-f[filter containers]:filter:()" \
+        "(- :)-h[display help dialog]" \
+        "($I)-i[invert default colors]" \
+        "($I)-r[reverse container sort order]" \
+        "($I)-s[select container sort field]:sort by:(id name cpu mem 'mem %' net pids io state)" \
+        "($I)-scale-cpu[show cpu as % of system total]" \
+        "(- :)-v[output version information and exit]"
 }


### PR DESCRIPTION
It was permitting invalid combinations.