### PR TITLE
Fixed Minikube None race condition

### DIFF
--- a/minikube-none/README.md
+++ b/minikube-none/README.md
@@ -1,7 +1,7 @@
 # Zsh Plugin: Minikube None
 
 Make [minikube](https://github.com/kubernetes/minikube) default to
-`--vm-driver=none`.
+`--vm-driver=none`. Also enables tab-completion support for Minikube.
 
 Essentially transforms:
 

--- a/minikube-none/minikube.plugin.zsh
+++ b/minikube-none/minikube.plugin.zsh
@@ -54,7 +54,11 @@ __minikube_none() {
     fi
 }
 
-alias minikube=__minikube_none
+if [[ $commands[minikube] ]]; then
+    source <(minikube completion zsh)
 
-# So tab-completion still works
-compdef __minikube_none='minikube'
+    alias minikube=__minikube_none
+
+    # So tab-completion still works
+    compdef __minikube_none='minikube'
+fi


### PR DESCRIPTION
This plugin would fail to work properly if it was loaded before the Minikube Zsh plugin. It should now be used instead of the Minikube Zsh plugin.